### PR TITLE
terminus 0.11.2 binary update

### DIFF
--- a/Formula/terminus.rb
+++ b/Formula/terminus.rb
@@ -6,8 +6,8 @@ class Terminus < Formula
 
   desc "Command-line interface for the Pantheon Platform"
   homepage "https://github.com/pantheon-systems/terminus"
-  url "https://github.com/pantheon-systems/terminus/archive/0.11.1.tar.gz"
-  sha256 "bb74ef83ee03c0baade0ba2bd5847158c9448a48064cb9c131c6cf1f4d2456d7"
+  url "https://github.com/pantheon-systems/terminus/releases/download/0.11.2/terminus.phar"
+  sha256 "9767f6bbd86e4eb7df186f805e97d608c42bcb9cbd6466a28f78061507d53a85"
   head "https://github.com/pantheon-systems/terminus.git"
 
   bottle do


### PR DESCRIPTION
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

This commit includes the latest stable version (0.11.2) of Terminus, and switches the download to the preferred `phar` filetype, rather than `tar.gz`.
